### PR TITLE
send recov vec to a separate recov key derived from nostr key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ after the setup, to ask for addresses, use whatever nostr client you want (that 
 ## TODO
 - [x] answer re-reqs with the same address if the previous address was not used in the transaction
 - [x] default to Wpkh instead of pkh
-- [x] support for multiple user-defined relays
+- [x] support for multiple user-defined relays (ux)
 - [x] support for ~~testnet~~ signet
-- [ ] support for different address types
-- [ ] support client-auth (nip 42)
-- [ ] support Req_pass
-- [ ] concat notes with random-sized arbitary strings
+- [x] support Req_pass (privacy, ux)
+- [x] save recov vec on a separate derived pubkey (privacy, ux)
 - [ ] reply to messages sent while the client was not running
-- [ ] support for DescReq and contact list
-- [ ] show deposits into covered addresses
 - [ ] add derivation paths to recovery notes
+- [ ] support client-auth (nip 42, privacy)
+- [ ] support Encrypted Payloads (Versioned)(nip 44, privacy)
+- [ ] Req_pass as label (ux)
+- [ ] concat notes with random-sized arbitary strings (privacy)
+- [ ] support for DescReq and contact list (ux)
+- [ ] show deposits into covered addresses (ux)
+- [ ] support for different address types (ux)
 
 ## Contact
 if you have any questions or want to contribute to this project, feel free to join [ASUN telegram group](https://t.me/ASUNDEV)

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,7 +13,7 @@ pub struct Args {
     #[arg(
         short = 'x',
         long = "extended-public-key",
-        default_value = "xpub6BqB4igvkyuLW28sMUx5KgLxpnW5AmkDdcRRAhYaMKVRVcY1fbntCKCDMwqko4DUUGHsQNwvMtMGpitSDmp7VFXqWTRtA95Fcw4XQFbut4Z",
+        default_value = "tpubDC6zXTLA5Y96rECsqNbU3JPYVCbn8kSUoh3vqHX1sKRfKP5SgMHN6Cy5txJhDEFsuKUnTQ745sye3PTdSWrSMhoJFwzfq5zGWwSZK5912aK",
         env = "XPUB"
     )]
     pub xpub: String,
@@ -64,7 +64,7 @@ pub struct Args {
     #[arg(
         short = 'n',
         long = "address-network [b:bitcoin/s:signet]",
-        default_value = "b",
+        default_value = "s",
         env = "ADDR_NETWORK"
     )]
     pub network: char,


### PR DESCRIPTION
instead of sending recovery messages to nostr pubkey itself send it to a separate one that is deterministically derived from the nostr key

ux advantage:
free up the message-to-self and better management of the messages and storage allocation
